### PR TITLE
Added help tooltips to home page

### DIFF
--- a/ioos_catalog/templates/dataset_help_text.txt
+++ b/ioos_catalog/templates/dataset_help_text.txt
@@ -1,0 +1,1 @@
+A dataset is some form of data produced by a service. Gridded data, point data, and observation data are just some of the datasets harvested from a service. A single service may produce one or more datasets.

--- a/ioos_catalog/templates/help.html
+++ b/ioos_catalog/templates/help.html
@@ -15,13 +15,13 @@
 
   <h4>What is a Service?</h4>
 
-  <p>A service or service endpoint is an accessible URL providing data access via a standard (e.g. SOS, DAP, WCS). Services are harvested via CSW from the NGDC geoportal on a nightly basis. The IOOS Catalog provides monitoring for uptime statistics and uses these services to extract Datasets.</p>
+  <p>{% include 'service_help_text.txt' %}</p>
 
   <p>The current supported services are DAP, SOS, WCS, and WMS.</p>
 
   <h4>What is a Dataset?</h4>
 
-  <p>A dataset is some form of data produced by a service. Gridded data, point data, and observation data are just some of the datasets harvested from a service. A single service may produce one or more datasets.</p>
+  <p>{% include 'dataset_help_text.txt' %}</p>
 
   <div class="alert alert-info">Only DAP and SOS datasets are currently supported.</div>
 

--- a/ioos_catalog/templates/index.html
+++ b/ioos_catalog/templates/index.html
@@ -23,12 +23,17 @@
         <p>2. Choose a filter:</p>
         <div class="row">
           <div class="col-lg-6">
-            <p><strong>Services</strong></p>
+            <p class="show-tooltip" data-toggle="tooltip" data-placement="left"
+               title="{% include 'service_help_text.txt' %}">
+              <strong>Services</strong>
+            </p>
             <div id="service-type-btns">
             </div>
           </div>
           <div class="col-lg-6">
-            <p><strong>Datasets</strong></p>
+            <p class="show-tooltip" data-toggle="tooltip" data-placement="left"
+              title="{% include 'dataset_help_text.txt' %}">
+              <strong>Datasets</strong></p>
             <div id="dataset-type-btns">
             </div>
           </div>
@@ -343,6 +348,9 @@ var dsTranslate = {
   "FIXED MET STATION": 'Fixed Met Station',
   BUOY: 'Buoy'
 };
+
+//activate help tooltips for services and datasets
+$('.show-tooltip').tooltip()
 
 </script>
 

--- a/ioos_catalog/templates/service_help_text.txt
+++ b/ioos_catalog/templates/service_help_text.txt
@@ -1,0 +1,1 @@
+A service or service endpoint is an accessible URL providing data access via a standard (e.g. SOS, DAP, WCS). Services are harvested via CSW from the NGDC Geoportal on a nightly basis. The IOOS Catalog provides monitoring for uptime statistics and uses these services to extract datasets.  


### PR DESCRIPTION
Implements #69.  Added help text directly to "Services" and "Datasets"
 heading via tooltips.  Moved help text to separate include file in raw text,
 which both the main help and home page now include.

Also fixed capitalization error on
"NGDC Geoportal" and decapitalized "datasets" near end of help text.
