### PR TITLE
Dataset dropdown populated from active services

### DIFF
--- a/ioos_catalog/views/dataset.py
+++ b/ioos_catalog/views/dataset.py
@@ -45,7 +45,11 @@ def datasets(filter_provider, filter_type):
     f          = DatasetFilterForm()
     datasets   = list(db.Dataset.find(filters))
     try:
-        assettypes = db.Dataset.find({}).distinct('services.asset_type')
+        # find all service ids with an associated active service endpoint
+        assettypes = (db.Dataset.find({'services.service_id':
+                                       {'$in': service_ids}},
+                                      {'services.asset_type': True})
+                                      .distinct('services.asset_type'))
     except:
         assettypes = []
 


### PR DESCRIPTION
Fixes #65 by eliminating dataset asset types with inactive service endpoints
from the selection menu on the datasets page.
