### PR TITLE
Adds logic to compute dataset bounding box using global attrs

### DIFF
--- a/ioos_catalog/tasks/harvest.py
+++ b/ioos_catalog/tasks/harvest.py
@@ -831,16 +831,20 @@ class DapHarvest(Harvester):
             if attr_name not in ncattrs:
                 break
         else: # All of them were found
-            lat_min = getattr(ncdataset, 'geospatial_lat_min')
-            lat_max = getattr(ncdataset, 'geospatial_lat_max')
-            lon_min = getattr(ncdataset, 'geospatial_lon_min')
-            lon_max = getattr(ncdataset, 'geospatial_lon_max')
+            # Sometimes the attributes are strings, which will cause the
+            # box calculation to fail.  Just to be sure, cast to float
+            try:
+                lat_min = float(ncdataset.geospatial_lat_min)
+                lat_max = float(ncdataset.geospatial_lat_max)
+                lon_min = float(ncdataset.geospatial_lon_min)
+                lon_max = float(ncdataset.geospatial_lon_max)
+            except ValueError:
+                app.logger.warning('Bbox calculation from global attributes '
+                                   'failed.  Likely due to uncastable string '
+                                   'to float value')
+                return None
 
             geometry = self.get_bbox_or_point([lon_min, lat_min,
                                                lon_max, lat_max])
             return geometry
         return None
-
-
-
-


### PR DESCRIPTION
We were wondering why nothing was showing up on the asset map for the CDIP datasets. After initial investigation we noted two things:
1. For the DAP datasets, the feature type was complicated and couldn't be reasoned by Paegan but the geospatial bounding box for the dataset was supplied in the NC_GLOBALS. This pull request looks for the global attributes in a netCDF dataset and identifies if there are globals defined which identify the bounding box.
2. SOS datasets aren't being harvested due to the SOS endpoint not being IOOS 1.0 compliant. We will investigate that further.
