### PR TITLE
Handle errors when not possible to open DAP endpoint

### DIFF
--- a/ioos_catalog/tasks/harvest.py
+++ b/ioos_catalog/tasks/harvest.py
@@ -531,7 +531,14 @@ class DapHarvest(Harvester):
           * DSG
         """
 
-        cd = CommonDataset.open(self.service.get('url'))
+        try:
+            cd = CommonDataset.open(self.service.get('url'))
+        except Exception as e:
+            app.logger.error("Could not open DAP dataset from '%s'\n"
+                             "Exception %s: %s" % (self.service.get('url'),
+                                                   type(e).__name__, e))
+            return 'Not harvested'
+
 
         # For DAP, the unique ID is the URL
         unique_id = self.service.get('url')


### PR DESCRIPTION
If the a DAP endpoint cannot be harvested, the harvest job will crash.  With this commit, an exception will be caught and logged when this happens instead, and allow the harvester to continue processing.
