### PR TITLE
Fixed select error when marker icon layer not present

### DIFF
--- a/ioos_catalog/templates/asset_map.html
+++ b/ioos_catalog/templates/asset_map.html
@@ -248,7 +248,10 @@ function click_layer(layer, feature) {
         if (lastLayer) {
             //check if station point
             pointFeatures.resetStyle(lastLayer);
-            map.removeLayer(targetLayer);
+            //remove any marker indicators for selected points if they exist
+            if (map.hasLayer(targetLayer)) {
+                map.removeLayer(targetLayer);
+            }
         }
         if (layer.feature.geometry.type === 'Point') {
             //reset the map object if we have removed the layer


### PR DESCRIPTION
If a point indicator icon layer does not exist or is not present, do not
attempt to remove it from the map.  This fixes some select problems when
polygon or linestring areas were selected instead of points, and 
subsequent selections would not bring up an info box for the data set.
