### PR TITLE
Greatly improved selection of polygons on map

### DIFF
--- a/ioos_catalog/templates/asset_map.html
+++ b/ioos_catalog/templates/asset_map.html
@@ -228,7 +228,8 @@ function highlight_layer_hover(layer) {
        /*if there's also a layer selected and it intersects with the hovered
         *layer, send it to the very back so the hover effect is kept
         *and the selected layer does not overlap it. */
-       if (lastLayer && lastLayer.getBounds().intersects(layer.getBounds())) {
+       if (lastLayer && lastLayer.feature.geometry.type == 'Polygon' &&
+           lastLayer.getBounds().intersects(layer.getBounds())) {
            lastLayer.bringToBack();
        }
    }


### PR DESCRIPTION
Polygons are now primarily selected by border.  The highlight effect is
still present from hover and selection, but now should not interfere with
selecting other polygon features.   Should also address issues where large numbers of
 semi-transparent polygons were obscuring the basemap as well.
