### PR TITLE
Reroute to home page from catalog map if using IE

### DIFF
--- a/ioos_catalog/templates/catalog_map.html
+++ b/ioos_catalog/templates/catalog_map.html
@@ -529,6 +529,10 @@ $(function() {
     defaultVal = '-';
   }
 
+  if (L.Browser.ie) {
+      alert('Catalog map is presently incompatible with Internet Explorer.');
+      window.location = '/';
+  }
   $('select').val(defaultVal, true).trigger('change');
 });
 


### PR DESCRIPTION
Goes back to home page if catalog map is selected while using IE.  Temporary until methods to fix map are found for IE.
