### PR TITLE
Fixes queue_harvests

### DIFF
--- a/ioos_catalog/tasks/harvest.py
+++ b/ioos_catalog/tasks/harvest.py
@@ -29,7 +29,7 @@ def queue_harvest_tasks():
         # shuffling our list of services we reduce the liklihood that we'll
         # harvest from the same host enough times to cause a service problem.
         # This should reduce timeouts and unresponsive datasets
-        services = list(db.Service.find({'active': True}, {'_id': True}))
+        services = list(db.Service.find({'active': True}))
         services = distinct_services(services)
         shuffle(services)
         for s in services:


### PR DESCRIPTION
The mongo query filtered out all fields except id which is not desired
since we need access to the fields to correctly find records with
distinct urls.

This patch removes the mongo filtering and returns the entire service
record.