### PR TITLE
Improves harvesting

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@ COMMON: &common
   # Logging and Debug
   DEBUG: False
   TESTING: False
-  LOG_FILE: True
+  LOG_FILE: logs/ioos_catalog.txt
   JSONIFY_PRETTYPRINT_REGULAR: False
   # Host configuration, only used by the app.py not used by gunicorn or WSGI
   # service

--- a/ioos_catalog/__init__.py
+++ b/ioos_catalog/__init__.py
@@ -26,13 +26,14 @@ from rq_dashboard import RQDashboard
 RQDashboard(app)
 
 # Create logging
-if app.config.get('LOG_FILE') == True:
+if app.config.get('LOG_FILE'):
     import logging
     from logging import FileHandler
-    file_handler = FileHandler('logs/ioos_catalog.txt')
+    file_handler = FileHandler(app.config['LOG_FILE'])
     formatter = logging.Formatter('%(asctime)s - %(process)d - %(name)s - %(module)s:%(lineno)d - %(levelname)s - %(message)s')
     file_handler.setFormatter(formatter)
-    file_handler.setLevel(logging.INFO)
+    config_logging_level = app.config.get('LOGGING_LEVEL', 'INFO')
+    file_handler.setLevel(getattr(logging, config_logging_level))
     app.logger.addHandler(file_handler)
     app.logger.info('Application Process Started')
 

--- a/ioos_catalog/static/css/ism-style.css
+++ b/ioos_catalog/static/css/ism-style.css
@@ -373,3 +373,10 @@ table.message-table {
   overflow-x: auto;
 }
 
+.table>thead>tr>td.unavailable,.table>tbody>tr>td.unavailable,.table>tfoot>tr>td.unavailable,.table>thead>tr>th.unavailable,.table>tbody>tr>th.unavailable,.table>tfoot>tr>th.unavailable,.table>thead>tr.unavailable>td,.table>tbody>tr.unavailable>td,.table>tfoot>tr.unavailable>td,.table>thead>tr.unavailable>th,.table>tbody>tr.unavailable>th,.table>tfoot>tr.unavailable>th {
+    background-color: #e8e8e8;
+}
+
+.table-hover>tbody>tr>td.unavailable:hover,.table-hover>tbody>tr>th.unavailable:hover,.table-hover>tbody>tr.unavailable:hover>td,.table-hover>tbody>tr.unavailable:hover>th {
+    background-color: #dcdcdc;
+}

--- a/ioos_catalog/templates/services.html
+++ b/ioos_catalog/templates/services.html
@@ -57,7 +57,17 @@
             </tr>
             {%- for service in service_group.list %}
             {%- set ss = service_stats[service._id] %}
-            <tr class="{{ "danger" if ss['last_operational_status'] == 0 and ss['last_update'] }}">
+            {% if ss['last_operational_status'] == 1 and ss['last_update'] %}
+            <tr class="danger">
+            {% elif ss['last_operational_status'] == 2 and ss['last_update'] %}
+            <tr class="warning">
+            {% elif ss['last_operational_status'] == 3 and ss['last_update'] %}
+            <tr class="unavailable">
+            {% elif ss['last_operational_status'] == 4 and ss['last_update'] %}
+            <tr class="unavailable">
+            {% else %}
+            <tr>
+            {% endif %}
                 <td>{{ service.data_provider }}</td>
                 <td>{{ service.service_type }}</td>
                 <td><a href="{{ url_for('show_service', service_id=service._id) }}">{{ service.name | truncate(40, True) }}</a></td>

--- a/ioos_catalog/templates/show_dataset.html
+++ b/ioos_catalog/templates/show_dataset.html
@@ -80,6 +80,8 @@
                 <li>{{ vv }}</li>
                 {%- endfor %}
               </ul>
+              {%- elif k == 'Describe Sensor URL' %}
+                <a href="{{v}}">Describe Sensor URL</a>
               {%- else %}
               {{ v }}
               {%- endif %}

--- a/ioos_catalog/templates/show_service.html
+++ b/ioos_catalog/templates/show_service.html
@@ -78,7 +78,15 @@
     <dl class="dl-horizontal col-lg-4">
       {% if harvest is not none %}
         <dt>Harvest Successful</dt>
-        <dd>{{ "<span class=\"label label-success\">YES</span>" | safe if harvest.harvest_successful else "<span class=\"label label-danger\">NO</span>" | safe }}</dd>
+        <dd>
+          {% if harvest.harvest_successful == 0 %}
+            <span class="label label-success">YES</span>
+          {% elif harvest.harvest_successful == 2 %}
+            <span class="label label-warning">Partial</span>
+          {% else %}
+            <span class="label label-danger">NO</span>
+          {% endif %}
+        </dd>
         <dt>Last Harvest Attempt</dt>
         <dd><abbr title="{{ harvest.harvest_date | datetimeformat }}">{{ harvest.harvest_date | prettydate }}</abbr></dd>
         <dt>Last Harvest Status</dt>


### PR DESCRIPTION
This patches the harvesting for SOS services. I removed the compliance
checker scores for SOS, they don't mean much right now. I hopefully
improved performance by caching the outputFormat so that if the
harvester finds an outputFormat for a particular service, it should keep
using that one instead of trying the list of them.

The formatting of the templates is changed so that there's more colors
than just red and clear. If a service is partially available (some
procedures worked) it will be yellow. If the service was unavailable it
will be gray. If it failed to parse correctly it's red.